### PR TITLE
Add bamboo grass feldweg only if ethereal is installed

### DIFF
--- a/mod.conf
+++ b/mod.conf
@@ -1,5 +1,5 @@
 name = cottages
 description = Contains a lot of blocks that fit to medieval settlements and small cottages. Comes with hammer & anvil to repair tools. Threshing floor and handmill help process grains etc.
-optional_depends = default, farming, stairs, homedecor, intllib, trees, wool, moreblocks
+optional_depends = default, farming, stairs, homedecor, intllib, trees, wool, moreblocks, ethereal
 author = Sokomine
 title = Blocks for building cottages.

--- a/nodes_feldweg.lua
+++ b/nodes_feldweg.lua
@@ -563,16 +563,18 @@ elseif( cottages_feldweg_mode == "mesh"
 		"default_dirt.png^default_dry_grass_side.png", -- side
 		"cottages_feldweg_surface.png^default_dry_grass.png",
 	}
-	variants["bamboo"] = {
-		"ethereal_grass_bamboo_top.png", -- grass top
-		"default_dirt.png", -- bottom
-		"default_dirt.png^ethereal_grass_bamboo_side.png", -- side
-		"_bamboo",
-		"ethereal:bamboo_dirt",
-		" on bamboo dirt",
-		"default_dirt.png^ethereal_grass_bamboo_side.png", -- side
-		"cottages_feldweg_surface.png^ethereal_grass_bamboo_top.png",
-	}
+	if minetest.get_modpath("ethereal") then
+		variants["bamboo"] = {
+			"ethereal_grass_bamboo_top.png", -- grass top
+			"default_dirt.png", -- bottom
+			"default_dirt.png^ethereal_grass_bamboo_side.png", -- side
+			"_bamboo",
+			"ethereal:bamboo_dirt",
+			" on bamboo dirt",
+			"default_dirt.png^ethereal_grass_bamboo_side.png", -- side
+			"cottages_feldweg_surface.png^ethereal_grass_bamboo_top.png",
+		}
+	end
 
 	for k, v in pairs(variants) do
 		cottages.register_nodes_mesh(v[4], v[1], v[2], v[3], cottages_feldweg_mode, v[6], v[7], v[8])


### PR DESCRIPTION
This PR adds ethereal as an optional dependency and restricts bamboo dirt feldweg to servers with ethereal installed.

This PR is ready for review.